### PR TITLE
Fix API definitions to generate rust code

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 // @title Rack of labs API
-// @version version(1.0)
+// @version 0.1.0
 // @description Description of specifications
 // @Precautions when using termsOfService specifications
 

--- a/src/webapi/controllers/AppLogGinController.go
+++ b/src/webapi/controllers/AppLogGinController.go
@@ -35,11 +35,11 @@ func RegisterAppLogController(controller *AppLogGinController, server *webapi.Gi
 // @Tags app log
 // @Accept  json
 // @Produce  json
-// @param	 orderBy			path	string	false	"Order by field"
-// @param	 orderDirection	path	string	false	"'asc' or 'desc' for ascending or descending order"
-// @param	 search			 path	string	false	"searchable value in entity"
-// @param	 page			 path	int		false	"page number"
-// @param	 pageSize		 path	int		false	"number of entities per page"
+// @param	 orderBy		 query	string	false	"Order by field"
+// @param	 orderDirection		 query	string	false	"'asc' or 'desc' for ascending or descending order"
+// @param	 search			 query	string	false	"searchable value in entity"
+// @param	 page			 query	int		false	"page number"
+// @param	 pageSize		 query	int		false	"number of entities per page"
 // @Success 200 {object} dtos.ResponseDataDto{data=dtos.PaginatedListDto{items=[]dtos.AppLogDto}} ""
 // @router /log/app/ [get]
 func (a *AppLogGinController) GetList(ctx *gin.Context) {

--- a/src/webapi/controllers/DeviceTemplateController.go
+++ b/src/webapi/controllers/DeviceTemplateController.go
@@ -45,11 +45,11 @@ func RegisterDeviceTemplateController(controller *DeviceTemplateController, serv
 // @Tags device template
 // @Accept  json
 // @Produce  json
-// @param 	orderBy			path	string	false	"Order by field"
-// @param 	orderDirection	path	string	false	"'asc' or 'desc' for ascending or descending order"
-// @param 	search 			path	string	false	"searchable value in entity"
-// @param 	page 			path	int		false	"page number"
-// @param 	pageSize 		path	int		false	"number of entities per page"
+// @param 	orderBy			query	string	false	"Order by field"
+// @param 	orderDirection		query	string	false	"'asc' or 'desc' for ascending or descending order"
+// @param 	search 			query	string	false	"searchable value in entity"
+// @param 	page 			query	int		false	"page number"
+// @param 	pageSize 		query	int		false	"number of entities per page"
 // @Success 200 {object} dtos.ResponseDataDto{data=dtos.PaginatedListDto{items=[]dtos.DeviceTemplateDto}} ""
 // @router /template/device/ [get]
 func (d *DeviceTemplateController) GetList(ctx *gin.Context) {

--- a/src/webapi/controllers/EthernetSwitchGinController.go
+++ b/src/webapi/controllers/EthernetSwitchGinController.go
@@ -39,11 +39,11 @@ func RegisterEthernetSwitchController(controller *EthernetSwitchGinController, s
 // @Tags ethernet-switch
 // @Accept  json
 // @Produce json
-// @param	 orderBy	     path	string	false	"Order by field"
-// @param	 orderDirection	 path	string	false	"'asc' or 'desc' for ascending or descending order"
-// @param	 search			 path	string	false	"Searchable value in entity"
-// @param	 page			 path	int		false	"Page number"
-// @param	 pageSize		 path	int		false	"Number of entities per page"
+// @param	 orderBy		 query	string	false	"Order by field"
+// @param	 orderDirection		 query	string	false	"'asc' or 'desc' for ascending or descending order"
+// @param	 search			 query	string	false	"Searchable value in entity"
+// @param	 page			 query	int		false	"Page number"
+// @param	 pageSize		 query	int		false	"Number of entities per page"
 // @Success 200 {object} dtos.ResponseDataDto{data=dtos.PaginatedListDto{items=[]dtos.EthernetSwitchDto}}
 // @router /ethernet-switch/ [get]
 func (e *EthernetSwitchGinController) GetList(ctx *gin.Context) {

--- a/src/webapi/controllers/EthernetSwitchPortGinController.go
+++ b/src/webapi/controllers/EthernetSwitchPortGinController.go
@@ -98,11 +98,11 @@ func (e *EthernetSwitchPortGinController) GetPortByID(ctx *gin.Context) {
 // @Accept  json
 // @Produce json
 // @param	 id	            path	string	true	"Ethernet switch ID"
-// @param	 orderBy		path	string	false	"Order by field"
-// @param	 orderDirection	path	string	false	"'asc' or 'desc' for ascending or descending order"
-// @param	 search			path	string	false	"Searchable value in entity"
-// @param	 page			path	int		false	"Page number"
-// @param	 pageSize		path	int		false	"Number of entities per page"
+// @param	 orderBy		query	string	false	"Order by field"
+// @param	 orderDirection		query	string	false	"'asc' or 'desc' for ascending or descending order"
+// @param	 search			query	string	false	"Searchable value in entity"
+// @param	 page			query	int		false	"Page number"
+// @param	 pageSize		query	int		false	"Number of entities per page"
 // @Success 200 {object} dtos.ResponseDataDto{data=dtos.PaginatedListDto{items=[]dtos.EthernetSwitchPortDto}} "desc"
 // @router /ethernet-switch/{id}/port/ [get]
 func (e *EthernetSwitchPortGinController) GetPorts(ctx *gin.Context) {

--- a/src/webapi/controllers/HttpLogGinController.go
+++ b/src/webapi/controllers/HttpLogGinController.go
@@ -1,11 +1,12 @@
 package controllers
 
 import (
-	"github.com/gin-gonic/gin"
 	"rol/app/interfaces"
 	"rol/domain"
 	"rol/dtos"
 	"rol/webapi"
+
+	"github.com/gin-gonic/gin"
 
 	"github.com/sirupsen/logrus"
 )
@@ -35,11 +36,11 @@ func RegisterHTTPLogController(controller *HTTPLogGinController, server *webapi.
 // @Tags http log
 // @Accept  json
 // @Produce  json
-// @param	 orderBy			path	string	false	"Order by field"
-// @param	 orderDirection	path	string	false	"'asc' or 'desc' for ascending or descending order"
-// @param	 search			 path	string	false	"searchable value in entity"
-// @param	 page			 path	int		false	"page number"
-// @param	 pageSize		 path	int		false	"number of entities per page"
+// @param	 orderBy		 query	string	false	"Order by field"
+// @param	 orderDirection		 query	string	false	"'asc' or 'desc' for ascending or descending order"
+// @param	 search			 query	string	false	"searchable value in entity"
+// @param	 page			 query	int		false	"page number"
+// @param	 pageSize		 query	int		false	"number of entities per page"
 // @Success 200 {object} dtos.ResponseDataDto{data=dtos.PaginatedListDto{items=[]dtos.HTTPLogDto}} "desc"
 // @router /log/http/ [get]
 func (h *HTTPLogGinController) GetList(ctx *gin.Context) {

--- a/src/webapi/swagger/docs.go
+++ b/src/webapi/swagger/docs.go
@@ -41,31 +41,31 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "Page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "Number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -307,31 +307,31 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "Page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "Number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -569,31 +569,31 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -693,31 +693,31 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -817,31 +817,31 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1384,7 +1384,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "version(1.0)",
+	Version:          "0.1.0",
 	Host:             "localhost:8080",
 	BasePath:         "/api/v1/",
 	Schemes:          []string{},

--- a/src/webapi/swagger/swagger.json
+++ b/src/webapi/swagger/swagger.json
@@ -12,7 +12,7 @@
             "name": "license(Mandatory)",
             "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "version(1.0)"
+        "version": "0.1.0"
     },
     "host": "localhost:8080",
     "basePath": "/api/v1/",
@@ -34,31 +34,31 @@
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "Page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "Number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -300,31 +300,31 @@
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "Page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "Number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -562,31 +562,31 @@
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -686,31 +686,31 @@
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -810,31 +810,31 @@
                         "type": "string",
                         "description": "Order by field",
                         "name": "orderBy",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "'asc' or 'desc' for ascending or descending order",
                         "name": "orderDirection",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "searchable value in entity",
                         "name": "search",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "page number",
                         "name": "page",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "number of entities per page",
                         "name": "pageSize",
-                        "in": "path"
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/src/webapi/swagger/swagger.yaml
+++ b/src/webapi/swagger/swagger.yaml
@@ -352,7 +352,7 @@ info:
     name: license(Mandatory)
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   title: Rack of labs API
-  version: version(1.0)
+  version: 0.1.0
 paths:
   /ethernet-switch/:
     get:
@@ -360,23 +360,23 @@ paths:
       - application/json
       parameters:
       - description: Order by field
-        in: path
+        in: query
         name: orderBy
         type: string
       - description: '''asc'' or ''desc'' for ascending or descending order'
-        in: path
+        in: query
         name: orderDirection
         type: string
       - description: Searchable value in entity
-        in: path
+        in: query
         name: search
         type: string
       - description: Page number
-        in: path
+        in: query
         name: page
         type: integer
       - description: Number of entities per page
-        in: path
+        in: query
         name: pageSize
         type: integer
       produces:
@@ -506,23 +506,23 @@ paths:
         required: true
         type: string
       - description: Order by field
-        in: path
+        in: query
         name: orderBy
         type: string
       - description: '''asc'' or ''desc'' for ascending or descending order'
-        in: path
+        in: query
         name: orderDirection
         type: string
       - description: Searchable value in entity
-        in: path
+        in: query
         name: search
         type: string
       - description: Page number
-        in: path
+        in: query
         name: page
         type: integer
       - description: Number of entities per page
-        in: path
+        in: query
         name: pageSize
         type: integer
       produces:
@@ -683,23 +683,23 @@ paths:
       - application/json
       parameters:
       - description: Order by field
-        in: path
+        in: query
         name: orderBy
         type: string
       - description: '''asc'' or ''desc'' for ascending or descending order'
-        in: path
+        in: query
         name: orderDirection
         type: string
       - description: searchable value in entity
-        in: path
+        in: query
         name: search
         type: string
       - description: page number
-        in: path
+        in: query
         name: page
         type: integer
       - description: number of entities per page
-        in: path
+        in: query
         name: pageSize
         type: integer
       produces:
@@ -755,23 +755,23 @@ paths:
       - application/json
       parameters:
       - description: Order by field
-        in: path
+        in: query
         name: orderBy
         type: string
       - description: '''asc'' or ''desc'' for ascending or descending order'
-        in: path
+        in: query
         name: orderDirection
         type: string
       - description: searchable value in entity
-        in: path
+        in: query
         name: search
         type: string
       - description: page number
-        in: path
+        in: query
         name: page
         type: integer
       - description: number of entities per page
-        in: path
+        in: query
         name: pageSize
         type: integer
       produces:
@@ -827,23 +827,23 @@ paths:
       - application/json
       parameters:
       - description: Order by field
-        in: path
+        in: query
         name: orderBy
         type: string
       - description: '''asc'' or ''desc'' for ascending or descending order'
-        in: path
+        in: query
         name: orderDirection
         type: string
       - description: searchable value in entity
-        in: path
+        in: query
         name: search
         type: string
       - description: page number
-        in: path
+        in: query
         name: page
         type: integer
       - description: number of entities per page
-        in: path
+        in: query
         name: pageSize
         type: integer
       produces:


### PR DESCRIPTION
- parameters coming after ? are query paramaters, not path parameters
- fix version numbering to be compatible with Rust Cargo versioning