### PR TITLE
src: switch all errors to custom errors

### DIFF
--- a/src/app/errors/CustomError.go
+++ b/src/app/errors/CustomError.go
@@ -5,6 +5,9 @@ import "fmt"
 //ErrorType is a custom error type
 type ErrorType uint
 
+//ValidationErrorMessage default message for validation errors
+const ValidationErrorMessage = "several validation errors occurred"
+
 const (
 	//NoType error without type
 	NoType = ErrorType(iota)

--- a/src/app/mappers/EntityDtoMapper.go
+++ b/src/app/mappers/EntityDtoMapper.go
@@ -1,7 +1,7 @@
 package mappers
 
 import (
-	"fmt"
+	"rol/app/errors"
 	"rol/domain"
 	"rol/dtos"
 )
@@ -25,7 +25,7 @@ func MapDtoToEntity(dto interface{}, entity interface{}) error {
 	case dtos.EthernetSwitchPortUpdateDto:
 		MapEthernetSwitchPortUpdateDto(dto.(dtos.EthernetSwitchPortUpdateDto), entity.(*domain.EthernetSwitchPort))
 	default:
-		return fmt.Errorf("[mapper]: Can't find route for map dto %+v to entity %+v", dto, entity)
+		return errors.Internal.Newf("can't find route for map dto %+v to entity %+v", dto, entity)
 	}
 	return nil
 }
@@ -54,7 +54,7 @@ func MapEntityToDto(entity interface{}, dto interface{}) error {
 	case domain.DeviceTemplate:
 		MapDeviceTemplateToDto(entity.(domain.DeviceTemplate), dto.(*dtos.DeviceTemplateDto))
 	default:
-		return fmt.Errorf("[mapper]: Can't find route for map entity %+v to dto %+v", entity, dto)
+		return errors.Internal.Newf("can't find route for map entity %+v to dto %+v", dto, entity)
 	}
 	return nil
 }

--- a/src/app/services/AppLogService.go
+++ b/src/app/services/AppLogService.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"rol/app/errors"
 	"rol/app/interfaces"
 	"rol/domain"
 	"rol/dtos"
@@ -30,5 +31,5 @@ func NewAppLogService(rep interfaces.IGenericRepository[domain.AppLog], log *log
 	genericService, err := NewGenericService[dtos.AppLogDto, dtos.AppLogDto, dtos.AppLogDto](rep, log)
 	return &AppLogService{
 		genericService,
-	}, err
+	}, errors.Internal.Wrap(err, "error constructing app log service")
 }

--- a/src/app/services/DeviceTemplateService.go
+++ b/src/app/services/DeviceTemplateService.go
@@ -2,8 +2,8 @@ package services
 
 import (
 	"context"
-	"fmt"
 	"github.com/sirupsen/logrus"
+	"rol/app/errors"
 	"rol/app/interfaces"
 	"rol/app/mappers"
 	"rol/app/utils"
@@ -55,17 +55,17 @@ func (d *DeviceTemplateService) GetList(ctx context.Context, search, orderBy, or
 	}
 	templatesArr, err := d.storage.GetList(ctx, orderBy, orderDirection, pageFinal, pageSizeFinal, queryBuilder)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get device templates: %s", err.Error())
+		return nil, errors.Internal.Wrap(err, "failed to get list of device templates")
 	}
 	count, err := d.storage.Count(ctx, queryBuilder)
 	if err != nil {
-		return nil, fmt.Errorf("failed to count device templates: %s", err.Error())
+		return nil, errors.Internal.Wrap(err, "failed to count device templates")
 	}
 	dtosArr := make([]dtos.DeviceTemplateDto, len(*templatesArr))
 	for i := range *templatesArr {
 		err := mappers.MapEntityToDto((*templatesArr)[i], &dtosArr[i])
 		if err != nil {
-			return nil, fmt.Errorf("failed to map template to dto: %s", err.Error())
+			return nil, errors.Internal.Wrap(err, "failed to map template to dto")
 		}
 	}
 	paginatedDto := new(dtos.PaginatedListDto[dtos.DeviceTemplateDto])
@@ -86,7 +86,7 @@ func (d *DeviceTemplateService) GetList(ctx context.Context, search, orderBy, or
 func (d *DeviceTemplateService) GetByName(ctx context.Context, templateName string) (*dtos.DeviceTemplateDto, error) {
 	template, err := d.storage.GetByName(ctx, templateName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get by name: %s", err.Error())
+		return nil, errors.Internal.Wrap(err, "failed to get template by name")
 	}
 	dto := new(dtos.DeviceTemplateDto)
 	mappers.MapDeviceTemplateToDto(*template, dto)

--- a/src/app/services/EthernetSwitchService.go
+++ b/src/app/services/EthernetSwitchService.go
@@ -2,9 +2,9 @@ package services
 
 import (
 	"context"
-	"fmt"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"rol/app/errors"
 	"rol/app/interfaces"
 	"rol/app/mappers"
 	"rol/app/validators"
@@ -35,7 +35,7 @@ func NewEthernetSwitchService(rep interfaces.IGenericRepository[domain.EthernetS
 	domain.EthernetSwitch], error) {
 	genericService, err := NewGenericService[dtos.EthernetSwitchDto, dtos.EthernetSwitchCreateDto, dtos.EthernetSwitchUpdateDto, domain.EthernetSwitch](rep, log)
 	if err != nil {
-		return nil, err
+		return nil, errors.Internal.Wrap(err, "error constructing ethernet switch service")
 	}
 	ethernetSwitchService := &EthernetSwitchService{
 		GenericService:       genericService,
@@ -84,7 +84,7 @@ func (e *EthernetSwitchService) modelIsSupported(model string) bool {
 	return modelIsSupported
 }
 
-func (e *EthernetSwitchService) serialIsUnique(ctx context.Context, serial string, id uuid.UUID) error {
+func (e *EthernetSwitchService) serialIsUnique(ctx context.Context, serial string, id uuid.UUID) (bool, error) {
 	uniqueSerialQueryBuilder := e.GenericService.repository.NewQueryBuilder(ctx)
 	e.GenericService.excludeDeleted(uniqueSerialQueryBuilder)
 	uniqueSerialQueryBuilder.Where("Serial", "==", serial)
@@ -93,15 +93,15 @@ func (e *EthernetSwitchService) serialIsUnique(ctx context.Context, serial strin
 	}
 	serialEthSwitchList, err := e.GenericService.repository.GetList(ctx, "", "asc", 1, 1, uniqueSerialQueryBuilder)
 	if err != nil {
-		return fmt.Errorf("get list error: %s", err)
+		return false, errors.Internal.Wrap(err, "service failed get list")
 	}
 	if len(*serialEthSwitchList) > 0 {
-		return fmt.Errorf("switch with this serial number already exist")
+		return false, nil
 	}
-	return nil
+	return true, nil
 }
 
-func (e *EthernetSwitchService) addressIsUnique(ctx context.Context, serial string, id uuid.UUID) error {
+func (e *EthernetSwitchService) addressIsUnique(ctx context.Context, serial string, id uuid.UUID) (bool, error) {
 	uniqueSerialQueryBuilder := e.GenericService.repository.NewQueryBuilder(ctx)
 	e.GenericService.excludeDeleted(uniqueSerialQueryBuilder)
 	uniqueSerialQueryBuilder.Where("Address", "==", serial)
@@ -110,12 +110,12 @@ func (e *EthernetSwitchService) addressIsUnique(ctx context.Context, serial stri
 	}
 	serialEthSwitchList, err := e.GenericService.repository.GetList(ctx, "", "asc", 1, 1, uniqueSerialQueryBuilder)
 	if err != nil {
-		return fmt.Errorf("get list error: %s", err)
+		return false, errors.Internal.Wrap(err, "failed to get ethernet switches from repository")
 	}
 	if len(*serialEthSwitchList) > 0 {
-		return fmt.Errorf("switch with this address already exist")
+		return false, nil
 	}
-	return nil
+	return true, nil
 }
 
 //GetList Get list of ethernet switches with filtering and pagination
@@ -130,7 +130,11 @@ func (e *EthernetSwitchService) addressIsUnique(ctx context.Context, serial stri
 //	*dtos.PaginatedListDto[dtos.EthernetSwitchDto] - pointer to paginated list of ethernet switches
 //	error - if an error occurs, otherwise nil
 func (e *EthernetSwitchService) GetList(ctx context.Context, search, orderBy, orderDirection string, page, pageSize int) (*dtos.PaginatedListDto[dtos.EthernetSwitchDto], error) {
-	return e.GenericService.GetList(ctx, search, orderBy, orderDirection, page, pageSize)
+	list, err := e.GenericService.GetList(ctx, search, orderBy, orderDirection, page, pageSize)
+	if err != nil {
+		return nil, errors.Internal.Wrap(err, "service failed get list")
+	}
+	return list, nil
 }
 
 //GetByID Get ethernet switch by ID
@@ -141,7 +145,11 @@ func (e *EthernetSwitchService) GetList(ctx context.Context, search, orderBy, or
 //	*dtos.EthernetSwitchDto - point to ethernet switch dto
 //	error - if an error occurs, otherwise nil
 func (e *EthernetSwitchService) GetByID(ctx context.Context, id uuid.UUID) (*dtos.EthernetSwitchDto, error) {
-	return e.GenericService.GetByID(ctx, id)
+	ethernetSwitch, err := e.GenericService.GetByID(ctx, id)
+	if err != nil {
+		return nil, errors.Internal.Wrap(err, "service failed get by id")
+	}
+	return ethernetSwitch, err
 }
 
 //Update save the changes to the existing ethernet switch
@@ -154,23 +162,36 @@ func (e *EthernetSwitchService) GetByID(ctx context.Context, id uuid.UUID) (*dto
 func (e *EthernetSwitchService) Update(ctx context.Context, updateDto dtos.EthernetSwitchUpdateDto, id uuid.UUID) error {
 	err := validators.ValidateEthernetSwitchUpdateDto(updateDto)
 	if err != nil {
-		return err
+		return err // we already wrap error in validators
 	}
 	if !e.modelIsSupported(updateDto.SwitchModel) {
-		return fmt.Errorf("switch model is not supported")
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		return errors.AddErrorContext(err, "SwitchModel", "this model is not supported")
 	}
 
-	err = e.serialIsUnique(ctx, updateDto.Serial, id)
+	uniqSerial, err := e.serialIsUnique(ctx, updateDto.Serial, id)
 	if err != nil {
-		return fmt.Errorf("serial number uniqueness check error: %s", err)
+		return errors.Internal.Wrap(err, "error occurred while checking uniqueness of the ethernet switch serial")
+	}
+	if !uniqSerial {
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		return errors.AddErrorContext(err, "Serial", "ethernet switch with this serial number already exist")
 	}
 
-	err = e.addressIsUnique(ctx, updateDto.Address, id)
+	uniqAddress, err := e.addressIsUnique(ctx, updateDto.Address, id)
 	if err != nil {
-		return fmt.Errorf("address uniqueness check error: %s", err)
+		return errors.Internal.Wrap(err, "address uniqueness check error")
+	}
+	if !uniqAddress {
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		return errors.AddErrorContext(err, "Address", "switch with this address already exist")
 	}
 
-	return e.GenericService.Update(ctx, updateDto, id)
+	err = e.GenericService.Update(ctx, updateDto, id)
+	if err != nil {
+		return errors.Internal.Wrap(err, "service failed to update entity")
+	}
+	return nil
 }
 
 //Create add new ethernet switch
@@ -183,20 +204,33 @@ func (e *EthernetSwitchService) Update(ctx context.Context, updateDto dtos.Ether
 func (e *EthernetSwitchService) Create(ctx context.Context, createDto dtos.EthernetSwitchCreateDto) (uuid.UUID, error) {
 	err := validators.ValidateEthernetSwitchCreateDto(createDto)
 	if err != nil {
-		return [16]byte{}, fmt.Errorf("dto validation error: %s", err)
+		return [16]byte{}, errors.Validation.Wrap(err, "validation failed")
 	}
 	if !e.modelIsSupported(createDto.SwitchModel) {
-		return [16]byte{}, fmt.Errorf("this switch model is not supported")
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		return [16]byte{}, errors.AddErrorContext(err, "SwitchModel", "this model is not supported")
 	}
-	err = e.serialIsUnique(ctx, createDto.Serial, [16]byte{})
+	uniqSerial, err := e.serialIsUnique(ctx, createDto.Serial, [16]byte{})
 	if err != nil {
-		return [16]byte{}, fmt.Errorf("serial number uniqueness check error: %s", err)
+		return [16]byte{}, errors.Internal.Wrap(err, "error occurred while checking uniqueness of the ethernet switch serial")
 	}
-	err = e.addressIsUnique(ctx, createDto.Address, [16]byte{})
+	if !uniqSerial {
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		return [16]byte{}, errors.AddErrorContext(err, "Serial", "ethernet switch with this serial number already exist")
+	}
+	uniqAddress, err := e.addressIsUnique(ctx, createDto.Address, [16]byte{})
 	if err != nil {
-		return [16]byte{}, fmt.Errorf("address uniqueness check error: %s", err)
+		return [16]byte{}, errors.Validation.Wrap(err, "address uniqueness check error")
 	}
-	return e.GenericService.Create(ctx, createDto)
+	if !uniqAddress {
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		return [16]byte{}, errors.AddErrorContext(err, "Address", "switch with this address already exist")
+	}
+	id, err := e.GenericService.Create(ctx, createDto)
+	if err != nil {
+		return [16]byte{}, errors.Internal.Wrap(err, "service failed to create entity")
+	}
+	return id, nil
 }
 
 //Delete mark ethernet switch as deleted
@@ -208,19 +242,19 @@ func (e *EthernetSwitchService) Create(ctx context.Context, createDto dtos.Ether
 func (e *EthernetSwitchService) Delete(ctx context.Context, id uuid.UUID) error {
 	err := e.GenericService.Delete(ctx, id)
 	if err != nil {
-		return err
+		return errors.Internal.Wrap(err, "service failed to delete entity")
 	}
 	queryBuilder := e.switchPortRepository.NewQueryBuilder(ctx)
 	queryBuilder.Where("EthernetSwitchID", "=", id)
 	ports, err := e.switchPortRepository.GetList(ctx, "", "", 1, 100, queryBuilder)
 	if err != nil {
-		return err
+		return errors.Internal.Wrap(err, "service failed get list")
 	}
 	for _, port := range *ports {
 		port.SetDeleted()
 		err := e.switchPortRepository.Update(ctx, &port)
 		if err != nil {
-			return err
+			return errors.Internal.Wrap(err, "service failed to update entity")
 		}
 	}
 	return nil

--- a/src/app/services/GenericService.go
+++ b/src/app/services/GenericService.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"rol/app/errors"
 	"rol/app/interfaces"
 	"rol/app/mappers"
 	"rol/app/utils"
@@ -103,18 +104,18 @@ func (g *GenericService[DtoType, CreateDtoType, UpdateDtoType, EntityType]) getL
 	}
 	entities, err := g.repository.GetList(ctx, orderBy, orderDirection, pageFinal, pageSizeFinal, queryBuilder)
 	if err != nil {
-		return nil, err
+		return nil, errors.Internal.New("repository failed get list")
 	}
 	count, err := g.repository.Count(ctx, queryBuilder)
 	if err != nil {
-		return nil, err
+		return nil, errors.Internal.Wrap(err, "error counting entities")
 	}
 	dtoArr := &[]DtoType{}
 	for i := 0; i < len(*entities); i++ {
 		dto := new(DtoType)
 		err = mappers.MapEntityToDto((*entities)[i], dto)
 		if err != nil {
-			return nil, fmt.Errorf("[%s]: [getList]: %s", g.logSourceName, err.Error())
+			return nil, errors.Internal.Wrap(err, "error map entity to dto")
 		}
 		*dtoArr = append(*dtoArr, *dto)
 	}
@@ -144,13 +145,17 @@ func (g *GenericService[DtoType, CreateDtoType, UpdateDtoType, EntityType]) GetL
 	if len(search) > 3 {
 		g.addSearchInAllFields(search, searchQueryBuilder)
 	}
-	return g.getListBasic(ctx, searchQueryBuilder, orderBy, orderDirection, page, pageSize)
+	list, err := g.getListBasic(ctx, searchQueryBuilder, orderBy, orderDirection, page, pageSize)
+	if err != nil {
+		return nil, errors.Internal.Wrap(err, "failed to get list ")
+	}
+	return list, nil
 }
 
 func (g *GenericService[DtoType, CreateDtoType, UpdateDtoType, EntityType]) getByIDBasic(ctx context.Context, id uuid.UUID, queryBuilder interfaces.IQueryBuilder) (*DtoType, error) {
 	entity, err := g.repository.GetByIDExtended(ctx, id, queryBuilder)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get by id: %s", err)
+		return nil, errors.Internal.Wrap(err, "failed to get by id")
 	}
 	if entity == nil {
 		return nil, nil
@@ -158,7 +163,7 @@ func (g *GenericService[DtoType, CreateDtoType, UpdateDtoType, EntityType]) getB
 	dto := new(DtoType)
 	err = mappers.MapEntityToDto(*entity, dto)
 	if err != nil {
-		return nil, fmt.Errorf("[%s]: [getByID]: %s", g.logSourceName, err.Error())
+		return nil, errors.Internal.Wrap(err, "error map entity to dto")
 	}
 	return dto, nil
 }
@@ -179,18 +184,18 @@ func (g *GenericService[DtoType, CreateDtoType, UpdateDtoType, EntityType]) GetB
 func (g *GenericService[DtoType, CreateDtoType, UpdateDtoType, EntityType]) updateBasic(ctx context.Context, updateDto UpdateDtoType, id uuid.UUID, queryBuilder interfaces.IQueryBuilder) error {
 	entity, err := g.repository.GetByIDExtended(ctx, id, queryBuilder)
 	if err != nil {
-		return fmt.Errorf("failed to get entity by id: %s", err)
+		return errors.Internal.Wrap(err, "failed to get entity by id")
 	}
 	if entity == nil {
-		return fmt.Errorf("failed to get entity by id: entity not found")
+		return errors.NotFound.Wrap(err, "entity not found")
 	}
 	err = mappers.MapDtoToEntity(updateDto, entity)
 	if err != nil {
-		return fmt.Errorf("failed to get entity by id: entity not found")
+		return errors.Internal.Wrap(err, "error map entity to dto")
 	}
 	err = g.repository.Update(ctx, entity)
 	if err != nil {
-		return fmt.Errorf("failed to update entity: %s", err)
+		return errors.Internal.Wrap(err, "failed to update entity in repository")
 	}
 	return nil
 }
@@ -219,11 +224,11 @@ func (g *GenericService[DtoType, CreateDtoType, UpdateDtoType, EntityType]) Crea
 	entity := new(EntityType)
 	err := mappers.MapDtoToEntity(createDto, entity)
 	if err != nil {
-		return uuid.UUID{}, fmt.Errorf("[%s]: [update]: %s", g.logSourceName, err.Error())
+		return uuid.UUID{}, errors.Internal.Wrap(err, "error map entity to dto")
 	}
 	id, err := g.repository.Insert(ctx, *entity)
 	if err != nil {
-		return uuid.UUID{}, err
+		return uuid.UUID{}, errors.Internal.Wrap(err, "create entity error")
 	}
 	return id, nil
 }
@@ -239,10 +244,10 @@ func (g *GenericService[DtoType, CreateDtoType, UpdateDtoType, EntityType]) Dele
 	g.excludeDeleted(queryBuilder)
 	entity, err := g.repository.GetByIDExtended(ctx, id, queryBuilder)
 	if err != nil {
-		return fmt.Errorf("failed to get entity by id: %s", err)
+		return errors.Internal.Wrap(err, "failed to get entity by id")
 	}
 	if entity == nil {
-		return fmt.Errorf("failed to get entity by id: entity not found")
+		return errors.NotFound.Wrap(err, "entity not found")
 	}
 
 	entityReflect := reflect.ValueOf(entity).Interface().(interfaces.IEntityModelDeletedAt)
@@ -250,7 +255,7 @@ func (g *GenericService[DtoType, CreateDtoType, UpdateDtoType, EntityType]) Dele
 
 	err = g.repository.Update(ctx, entity)
 	if err != nil {
-		return err
+		return errors.Internal.Wrap(err, "failed to update entity in the repository")
 	}
 	return nil
 }

--- a/src/app/services/HttpLogService.go
+++ b/src/app/services/HttpLogService.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"rol/app/errors"
 	"rol/app/interfaces"
 	"rol/domain"
 	"rol/dtos"
@@ -31,5 +32,5 @@ func NewHTTPLogService(rep interfaces.IGenericRepository[domain.HTTPLog], log *l
 	genericSerice, err := NewGenericService[dtos.HTTPLogDto, dtos.HTTPLogDto, dtos.HTTPLogDto](rep, log)
 	return HTTPLogService{
 		genericSerice,
-	}, err
+	}, errors.Internal.Wrap(err, "error constructing http log service")
 }

--- a/src/app/validators/DefaultRegexpAndValidatorFuncs.go
+++ b/src/app/validators/DefaultRegexpAndValidatorFuncs.go
@@ -1,7 +1,7 @@
 package validators
 
 import (
-	"fmt"
+	"rol/app/errors"
 	"strings"
 )
 
@@ -16,7 +16,7 @@ const regexpIPv4Desc = "wrong IPv4 format"
 func trimValidation(value interface{}) error {
 	s, _ := value.(string)
 	if strings.TrimSpace(s) != s {
-		return fmt.Errorf("field cannot start or end with spaces")
+		return errors.Validation.New("field cannot start or end with spaces")
 	}
 	return nil
 }
@@ -24,7 +24,7 @@ func trimValidation(value interface{}) error {
 func containsSpacesValidation(value interface{}) error {
 	s, _ := value.(string)
 	if strings.Contains(s, " ") {
-		return fmt.Errorf("field cannot contain spaces")
+		return errors.Validation.New("field cannot contain spaces")
 	}
 	return nil
 }

--- a/src/app/validators/EthernetSwitchCreateDto.go
+++ b/src/app/validators/EthernetSwitchCreateDto.go
@@ -3,6 +3,7 @@ package validators
 import (
 	validation "github.com/go-ozzo/ozzo-validation"
 	"regexp"
+	"rol/app/errors"
 	"rol/dtos"
 )
 
@@ -10,7 +11,8 @@ import (
 //	Return
 //	error - if an error occurs, otherwise nil
 func ValidateEthernetSwitchCreateDto(dto dtos.EthernetSwitchCreateDto) error {
-	return validation.ValidateStruct(&dto,
+	var err error
+	validationErr := validation.ValidateStruct(&dto,
 		validation.Field(&dto.Serial, []validation.Rule{
 			validation.Required,
 			validation.By(trimValidation),
@@ -39,4 +41,11 @@ func ValidateEthernetSwitchCreateDto(dto dtos.EthernetSwitchCreateDto) error {
 			validation.Required,
 			validation.By(trimValidation),
 		}...))
+	if validationErr != nil {
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		for key, value := range validationErr.(validation.Errors) {
+			err = errors.AddErrorContext(err, key, value.Error())
+		}
+	}
+	return err
 }

--- a/src/app/validators/EthernetSwitchPortCreateDto.go
+++ b/src/app/validators/EthernetSwitchPortCreateDto.go
@@ -1,8 +1,8 @@
 package validators
 
 import (
-	"fmt"
 	validation "github.com/go-ozzo/ozzo-validation"
+	"rol/app/errors"
 	"rol/dtos"
 )
 
@@ -14,7 +14,7 @@ func validatePOEType(value interface{}) error {
 	case "passive24":
 	case "none":
 	default:
-		return fmt.Errorf("wrong poe power type")
+		return errors.Internal.New("wrong poe power type")
 
 	}
 	return nil
@@ -24,7 +24,8 @@ func validatePOEType(value interface{}) error {
 //	Return
 //	error - if an error occurs, otherwise nil
 func ValidateEthernetSwitchPortCreateDto(dto dtos.EthernetSwitchPortCreateDto) error {
-	return validation.ValidateStruct(&dto,
+	var err error
+	validationErr := validation.ValidateStruct(&dto,
 		validation.Field(&dto.Name, []validation.Rule{
 			validation.Required,
 			validation.By(trimValidation),
@@ -36,4 +37,11 @@ func ValidateEthernetSwitchPortCreateDto(dto dtos.EthernetSwitchPortCreateDto) e
 			validation.By(containsSpacesValidation),
 			validation.By(validatePOEType),
 		}...))
+	if validationErr != nil {
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		for key, value := range validationErr.(validation.Errors) {
+			err = errors.AddErrorContext(err, key, value.Error())
+		}
+	}
+	return err
 }

--- a/src/app/validators/EthernetSwitchPortUpdateDto.go
+++ b/src/app/validators/EthernetSwitchPortUpdateDto.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	validation "github.com/go-ozzo/ozzo-validation"
+	"rol/app/errors"
 	"rol/dtos"
 )
 
@@ -9,7 +10,8 @@ import (
 //	Return
 //	error - if an error occurs, otherwise nil
 func ValidateEthernetSwitchPortUpdateDto(dto dtos.EthernetSwitchPortUpdateDto) error {
-	return validation.ValidateStruct(&dto,
+	var err error
+	validationErr := validation.ValidateStruct(&dto,
 		validation.Field(&dto.Name, []validation.Rule{
 			validation.Required,
 			validation.By(trimValidation),
@@ -21,4 +23,11 @@ func ValidateEthernetSwitchPortUpdateDto(dto dtos.EthernetSwitchPortUpdateDto) e
 			validation.By(containsSpacesValidation),
 			validation.By(validatePOEType),
 		}...))
+	if validationErr != nil {
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		for key, value := range validationErr.(validation.Errors) {
+			err = errors.AddErrorContext(err, key, value.Error())
+		}
+	}
+	return err
 }

--- a/src/app/validators/EthernetSwitchUpdateDto.go
+++ b/src/app/validators/EthernetSwitchUpdateDto.go
@@ -3,6 +3,7 @@ package validators
 import (
 	validation "github.com/go-ozzo/ozzo-validation"
 	"regexp"
+	"rol/app/errors"
 	"rol/dtos"
 )
 
@@ -10,7 +11,8 @@ import (
 //	Return
 //	error - if an error occurs, otherwise nil
 func ValidateEthernetSwitchUpdateDto(dto dtos.EthernetSwitchUpdateDto) error {
-	return validation.ValidateStruct(&dto,
+	var err error
+	validationErr := validation.ValidateStruct(&dto,
 		validation.Field(&dto.Name, []validation.Rule{
 			validation.Required,
 			validation.By(trimValidation),
@@ -39,4 +41,11 @@ func ValidateEthernetSwitchUpdateDto(dto dtos.EthernetSwitchUpdateDto) error {
 			validation.Required,
 			validation.By(trimValidation),
 		}...))
+	if validationErr != nil {
+		err = errors.Validation.New(errors.ValidationErrorMessage)
+		for key, value := range validationErr.(validation.Errors) {
+			err = errors.AddErrorContext(err, key, value.Error())
+		}
+	}
+	return err
 }

--- a/src/infrastructure/GormQueryBuilder.go
+++ b/src/infrastructure/GormQueryBuilder.go
@@ -1,9 +1,9 @@
 package infrastructure
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
+	"rol/app/errors"
 	"rol/app/interfaces"
 	"strings"
 )
@@ -112,7 +112,7 @@ func (g *GormQueryBuilder) OrQuery(builder interfaces.IQueryBuilder) interfaces.
 //	error - if error occurs return error, otherwise nil
 func (g *GormQueryBuilder) Build() (interface{}, error) {
 	if len(g.QueryString) < 1 {
-		return nil, errors.New("queryBuilder is empty")
+		return nil, errors.Internal.New("queryBuilder is empty")
 	}
 	arr := make([]interface{}, 0)
 	arr = append(arr, g.QueryString)

--- a/src/infrastructure/LogrusLogger.go
+++ b/src/infrastructure/LogrusLogger.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"os"
+	"rol/app/errors"
 	"rol/app/interfaces"
 	"rol/domain"
 
@@ -22,7 +23,7 @@ func NewLogrusLogger(config *domain.AppConfig) (*logrus.Logger, error) {
 	var err error
 	logger.Level, err = logrus.ParseLevel(config.Logger.Level)
 	if err != nil {
-		return nil, err
+		return nil, errors.Internal.Wrap(err, "failed to parse logrus level")
 	}
 	return logger, nil
 }

--- a/src/infrastructure/YmlConfig.go
+++ b/src/infrastructure/YmlConfig.go
@@ -1,9 +1,9 @@
 package infrastructure
 
 import (
-	"fmt"
 	"os"
 	"path"
+	"rol/app/errors"
 	"rol/domain"
 
 	"gopkg.in/yaml.v2"
@@ -19,14 +19,14 @@ func NewYmlConfig() (*domain.AppConfig, error) {
 	configFilePath := path.Join(path.Dir(ex), "appConfig.yml")
 	f, err := os.Open(configFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("[NewYmlConfig]: Failed to open config file %s: %v", configFilePath, err)
+		return nil, errors.Internal.Wrapf(err, "failed to open config file %s", configFilePath)
 	}
 	defer f.Close()
 
 	decoder := yaml.NewDecoder(f)
 	err = decoder.Decode(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("[NewYmlConfig]: Failed to parse yml config file %s: %v", configFilePath, err)
+		return nil, errors.Internal.Wrapf(err, "failed to parse yml config file %s", configFilePath)
 	}
 	return cfg, nil
 }

--- a/src/tests/EthernetSwitchDtoValidation_test.go
+++ b/src/tests/EthernetSwitchDtoValidation_test.go
@@ -1,7 +1,7 @@
 package tests
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	"rol/app/errors"
 	"rol/app/validators"
 	"rol/dtos"
 	"testing"
@@ -13,6 +13,7 @@ var (
 )
 
 func Test_EthernetSwitchCreateDto(t *testing.T) {
+
 	dto := dtos.EthernetSwitchCreateDto{
 		EthernetSwitchBaseDto: dtos.EthernetSwitchBaseDto{
 			Name:        " Validate ",
@@ -25,8 +26,9 @@ func Test_EthernetSwitchCreateDto(t *testing.T) {
 		Password: "AutoPass",
 	}
 	err := validators.ValidateEthernetSwitchCreateDto(dto)
-	for fieldName, errDescription := range err.(validation.Errors) {
-		if errDescription.Error() != blankErr && errDescription.Error() != whitespaceErr {
+	errContext := errors.GetErrorContext(err)
+	for fieldName, errDescription := range errContext {
+		if errDescription != blankErr && errDescription != whitespaceErr {
 			t.Errorf("%s: %s", fieldName, errDescription)
 		}
 	}
@@ -45,8 +47,9 @@ func Test_EthernetSwitchUpdateDto(t *testing.T) {
 		Password: "AutoPass",
 	}
 	err := validators.ValidateEthernetSwitchUpdateDto(dto)
-	for fieldName, errDescription := range err.(validation.Errors) {
-		if errDescription.Error() != blankErr && errDescription.Error() != whitespaceErr {
+	errContext := errors.GetErrorContext(err)
+	for fieldName, errDescription := range errContext {
+		if errDescription != blankErr && errDescription != whitespaceErr {
 			t.Errorf("%s: %s", fieldName, errDescription)
 		}
 	}

--- a/src/tests/EthernetSwitchPortService_test.go
+++ b/src/tests/EthernetSwitchPortService_test.go
@@ -81,7 +81,7 @@ func Test_EthernetSwitchPortService_CreatePortWithoutSwitch(t *testing.T) {
 	service := switchPortService.(*services.EthernetSwitchPortService)
 	_, err := service.CreatePort(context.TODO(), uuid.New(), dto)
 	if err == nil {
-		t.Errorf("nil error, expected: failed to get ethernet switch: switch not found")
+		t.Errorf("nil error, expected: error when checking the existence of the switch: switch not found")
 	}
 }
 

--- a/src/tests/GenericServiceTest.go
+++ b/src/tests/GenericServiceTest.go
@@ -14,9 +14,9 @@ import (
 
 //GenericServiceTest generic test for generic service
 type GenericServiceTest[DtoType interface{},
-	CreateDtoType interface{},
-	UpdateDtoType interface{},
-	EntityType interfaces.IEntityModel] struct {
+CreateDtoType interface{},
+UpdateDtoType interface{},
+EntityType interfaces.IEntityModel] struct {
 	Service interfaces.IGenericService[
 		DtoType,
 		CreateDtoType,
@@ -31,13 +31,13 @@ type GenericServiceTest[DtoType interface{},
 
 //NewGenericServiceTest GenericServiceTest constructor
 func NewGenericServiceTest[DtoType interface{},
-	CreateDtoType interface{},
-	UpdateDtoType interface{},
-	EntityType interfaces.IEntityModel](
+CreateDtoType interface{},
+UpdateDtoType interface{},
+EntityType interfaces.IEntityModel](
 	service interfaces.IGenericService[DtoType,
-		CreateDtoType,
-		UpdateDtoType,
-		EntityType],
+	CreateDtoType,
+	UpdateDtoType,
+	EntityType],
 	repo interfaces.IGenericRepository[EntityType], dbName string) *GenericServiceTest[DtoType, CreateDtoType, UpdateDtoType, EntityType] {
 	return &GenericServiceTest[DtoType, CreateDtoType, UpdateDtoType, EntityType]{
 		Service:    service,
@@ -50,11 +50,7 @@ func NewGenericServiceTest[DtoType interface{},
 
 //GenericServiceCreate test create entity
 func (g *GenericServiceTest[DtoType, CreateDtoType, UpdateDtoType, EntityType]) GenericServiceCreate(dto CreateDtoType) (uuid.UUID, error) {
-	id, err := g.Service.Create(g.Context, dto)
-	if err != nil {
-		return [16]byte{}, fmt.Errorf("create failed: %s", err)
-	}
-	return id, nil
+	return g.Service.Create(g.Context, dto)
 }
 
 //GenericServiceGetByID test get entity by id


### PR DESCRIPTION
The first part of replacing errors with custom ones.

Switching to custom typed errors will allow us to handle them more flexibly and store more information, as well as move from one error implementation to another.

Signed-off-by: Dmitrii Aleksandrov <goodmobiledevices@gmail.com>